### PR TITLE
Add dsub support

### DIFF
--- a/extract-pack/Dockerfile
+++ b/extract-pack/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8.6
+
+RUN git clone https://github.com/pbilling/pgxpop-pack.git
+
+RUN pip install -r pgxpop-pack/extract-pack/requirements.txt
+
+RUN echo -e 'python3 /pgxpop-pack/extract-pack/main.py' > \
+    /usr/bin/pgx-extract && \
+    chmod +x /usr/bin/pgx-extract

--- a/extract-pack/Dockerfile
+++ b/extract-pack/Dockerfile
@@ -1,11 +1,6 @@
 FROM python:3.8.6
 
-#RUN git clone https://github.com/pbilling/pgxpop-pack.git
 RUN mkdir -p /pgxpop-pack/extract-pack
 COPY . /pgxpop-pack/extract-pack/
 
 RUN pip install -r /pgxpop-pack/extract-pack/requirements.txt
-
-RUN echo -e '#!/bin/bash\npython3 /pgxpop-pack/extract-pack/main.py' > \
-    /usr/bin/pgx-extract && \
-    chmod +x /usr/bin/pgx-extract

--- a/extract-pack/Dockerfile
+++ b/extract-pack/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.8.6
 
-RUN git clone https://github.com/pbilling/pgxpop-pack.git
+#RUN git clone https://github.com/pbilling/pgxpop-pack.git
+RUN mkdir -p /pgxpop-pack/extract-pack
+COPY . /pgxpop-pack/extract-pack/
 
-RUN pip install -r pgxpop-pack/extract-pack/requirements.txt
+RUN pip install -r /pgxpop-pack/extract-pack/requirements.txt
 
-RUN echo -e 'python3 /pgxpop-pack/extract-pack/main.py' > \
+RUN echo -e '#!/bin/bash\npython3 /pgxpop-pack/extract-pack/main.py' > \
     /usr/bin/pgx-extract && \
     chmod +x /usr/bin/pgx-extract

--- a/extract-pack/README.md
+++ b/extract-pack/README.md
@@ -10,18 +10,6 @@ This command will create a docker image named 'extract-pack'.
 pack build --builder gcr.io/buildpacks/builder:v1 extract-pack --env GOOGLE_ENTRYPOINT="python main.py"
 ```
 
-## Create the image using Docker
-Run this in the same directory as the Dockerfile to generate a Docker image.
-```
-docker build --tag extract-pack .
-```
-
-## Dsub command for extracting regions
-```
-pgx-extract --vcf ${VCF} --bed ${BED} --fasta ${FASTA_REF} --output ${BCF} --index ${BCF_INDEX}
-```
-
-
 ## Run
 The script will automatically check `/workspace/input/` for input data.  The input VCF, index, fasta, and fasta indices need to be copied into the workspace.  The output directory also needs to be mounted in `/workspace/output`. 
 
@@ -62,6 +50,17 @@ extract-pack image is here on GCR
 gcr.io/gbsc-gcp-project-mvp-dev/extract-pack
 ```
 
+
+## Create the image using Docker
+Run this in the same directory as the Dockerfile to generate a Docker image.
+```
+docker build --tag extract-pack .
+```
+
+## Dsub command for extracting regions
+```
+pgx-extract --vcf ${VCF} --bed ${BED} --fasta ${FASTA_REF} --output ${BCF} --index ${BCF_INDEX}
+```
 
 
 

--- a/extract-pack/README.md
+++ b/extract-pack/README.md
@@ -3,12 +3,24 @@
 Extract genomics regions from a gVCF and expand the blocks.
 
 
-## Create the docker image
+## Create the docker image using buildpacks
 Create the docker environment using [buildpacks](https://cloud.google.com/blog/products/containers-kubernetes/google-cloud-now-supports-buildpacks). 
 This command will create a docker image named 'extract-pack'.
 ```
 pack build --builder gcr.io/buildpacks/builder:v1 extract-pack --env GOOGLE_ENTRYPOINT="python main.py"
 ```
+
+## Create the image using Docker
+Run this in the same directory as the Dockerfile to generate a Docker image.
+```
+docker build --tag extract-pack .
+```
+
+## Dsub command for extracting regions
+```
+pgx-extract --vcf ${VCF} --bed ${BED} --fasta ${FASTA_REF} --output ${BCF} --index ${BCF_INDEX}
+```
+
 
 ## Run
 The script will automatically check `/workspace/input/` for input data.  The input VCF, index, fasta, and fasta indices need to be copied into the workspace.  The output directory also needs to be mounted in `/workspace/output`. 

--- a/extract-pack/README.md
+++ b/extract-pack/README.md
@@ -56,6 +56,8 @@ gcr.io/gbsc-gcp-project-mvp-dev/extract-pack
 Run this in the same directory as the Dockerfile to generate a Docker image.
 ```
 docker build --tag extract-pack .
+docker tag extract-pack:1.0 gcr.io/gbsc-gcp-project-mvp-dev/pgxpop/extract-pack:1.0
+docker push gcr.io/gbsc-gcp-project-mvp-dev/pgxpop/extract-pack:1.0
 ```
 
 ## Dsub command for extracting regions

--- a/extract-pack/README.md
+++ b/extract-pack/README.md
@@ -50,6 +50,7 @@ extract-pack image is here on GCR
 gcr.io/gbsc-gcp-project-mvp-dev/extract-pack
 ```
 
+# Run via Dsub on Google Cloud
 
 ## Create the image using Docker
 Run this in the same directory as the Dockerfile to generate a Docker image.
@@ -58,8 +59,28 @@ docker build --tag extract-pack .
 ```
 
 ## Dsub command for extracting regions
+You can get the dsub tool here: https://github.com/DataBiosphere/dsub. Dsub is a tool to submit jobs to the Cloud Life Sciences API: https://cloud.google.com/life-sciences/docs/reference/rest.
+
 ```
-pgx-extract --vcf ${VCF} --bed ${BED} --fasta ${FASTA_REF} --output ${BCF} --index ${BCF_INDEX}
+dsub \
+    --name pgx-extract \
+    --provider google-v2 \
+    --regions us-west1 \
+    --project gbsc-gcp-project-mvp-dev \
+    --min-cores 1 \
+    --logging gs://gbsc-gcp-project-mvp-dev-from-personalis-phase3-logs/pgx-extract-test/ \
+    --image gcr.io/gbsc-gcp-project-mvp-dev/pgxpop/extract-pack:1.0 \
+    --use-private-address \
+    --network trellis \
+    --subnetwork trellis-us-west1 \
+    --command 'python3 /pgxpop-pack/extract-pack/main.py --vcf ${VCF} --bed ${BED} --fasta ${FASTA_REF} --output ${BCF} --index ${BCF_INDEX}' \
+    --input VCF=gs://gbsc-gcp-project-mvp-dev-from-personalis-phase3-data/DVALABP000398/SHIP4946374/gatk-5-dollar/201016-010219-048-8abfcd56/output/germline_single_sample_workflow/b89444cb-77b5-4b13-9824-b6ffd54db190/call-MergeVCFs/SHIP4946374.g.vcf.gz \
+    --input FASTA_INDEX=gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai \
+    --input VCF_INDEX=gs://gbsc-gcp-project-mvp-dev-from-personalis-phase3-data/DVALABP000398/SHIP4946374/gatk-5-dollar/201016-010219-048-8abfcd56/output/germline_single_sample_workflow/b89444cb-77b5-4b13-9824-b6ffd54db190/call-MergeVCFs/SHIP4946374.g.vcf.gz.tbi \
+    --input FASTA_REF=gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta \
+    --input BED=gs://gbsc-gcp-project-mvp-dev-trellis/pgx.grch38.bed \
+    --output BCF=gs://gbsc-gcp-project-mvp-dev-from-personalis-phase3-data/extract-vcf-regions/pgx-pop/output/SHIP4946374.pgx-pop.bcf \
+    --output BCF_INDEX=gs://gbsc-gcp-project-mvp-dev-from-personalis-phase3-data/extract-vcf-regions/pgx-pop/output/SHIP4946374.pgx-pop.bcf.csi
 ```
 
 

--- a/extract-pack/lib.py
+++ b/extract-pack/lib.py
@@ -441,6 +441,7 @@ def break_blocks(vcf, fasta, output, index, bed=None, filter=False, debug=False)
     print("Validating variant counts")
     vcf_count = count_variants(outfilename)
     norm_count = count_variants(normalized_bcf)
+    print(f"Variant counts: {vcf_count}, {norm_count}.")
 
     if vcf_count != norm_count:
         # something bad happened.  Log it

--- a/extract-pack/lib.py
+++ b/extract-pack/lib.py
@@ -296,7 +296,7 @@ def get_output_name(file):
     output_path = os.path.join("output", output_name)
     return output_path
 
-def break_blocks(vcf, fasta, bed=None, filter=False, debug=False):
+def break_blocks(vcf, fasta, output, index, bed=None, filter=False, debug=False):
     # Write a new vcf by extracting calls from the input vcf and breaking apart reference call blocks
 
     # Get the bed regions
@@ -442,8 +442,13 @@ def break_blocks(vcf, fasta, bed=None, filter=False, debug=False):
     # Clean up output
     os.remove(outfilename)
     os.remove(bcf)
-    os.rename(normalized_bcf, bcf)
-    os.rename(normalized_bcf + ".csi", bcf + ".csi")
+    #os.rename(normalized_bcf, bcf)
+    #os.rename(normalized_bcf + ".csi", bcf + ".csi")
+
+    # (pbilling) Delocalization of outputs is controlled by dsub
+    #   so we need to use the paths it generates for all outputs
+    os.rename(normaized_bcf, output)
+    os.rename(normalized_bcf + ".csv", index)
 
 
 def normalize_indels(vcf, output=None):

--- a/extract-pack/main.py
+++ b/extract-pack/main.py
@@ -81,14 +81,14 @@ Parse the command line
 def parse_command_line():
     parser = argparse.ArgumentParser(
         description = 'This is a script I wrote')
-    parser.add_argument("-v", "--vcf", help="gVCF to process")
+    parser.add_argument("-v", "--vcf", required=True, help="gVCF to process")
     parser.add_argument("-b", "--bed", help="Bed file for subsetting genotypes")
-    parser.add_argument("--fasta", help="Indexed reference genome fasta file.  Index must be in the same location")
-    parser.add_argument("-o", "--output", help="Output bcf file")
+    parser.add_argument("--fasta", required=True, help="Indexed reference genome fasta file.  Index must be in the same location")
+    parser.add_argument("-o", "--output", required=True, help="Output bcf file")
     # (pbilling) Specifying index name because dsub needs to manage 
     #   file paths of all inputs/outputs in order to do delocalize
     #   to Google Cloud Storage
-    parser.add_argument("-i", "--index", help="Output bcf index")
+    parser.add_argument("-i", "--index", required=True, help="Output bcf index")
     parser.add_argument("-d", "--debug", action='store_true', default=False,
                                 help="Output debugging messages.  May be very verbose.")
     options = parser.parse_args()
@@ -101,7 +101,8 @@ Main
 if __name__ == "__main__":
     print("Running VCF extraction")
     options = parse_command_line()
-    ep = ExtractPack(file=options.vcf,
+    ep = ExtractPack(
+                     vcf=options.vcf,
                      bed=options.bed,
                      fasta=options.fasta,
                      output=options.output,

--- a/extract-pack/main.py
+++ b/extract-pack/main.py
@@ -108,5 +108,6 @@ if __name__ == "__main__":
                      output=options.output,
                      index=options.index,
                      debug=options.debug)
+    print(f"Options: {options}.")
     ep.run()
 

--- a/extract-pack/main.py
+++ b/extract-pack/main.py
@@ -19,11 +19,12 @@ Then extract the name from the header and use that as the prefix
 
 
 class ExtractPack(object):
-    def __init__(self, file, fasta, output=None, bed=None, debug=False):
-        self.file = file
+    def __init__(self, vcf, fasta, output, index, bed=None, debug=False):
+        self.vcf = vcf
         self.fasta = fasta
         self.bed = bed
         self.output = output
+        self.index = index
         self.debug = debug
 
         if self.bed is None:
@@ -31,25 +32,33 @@ class ExtractPack(object):
 
     def run(self):
 
+        # (pbilling) Commenting out: only run on single VCF which 
+        #   is managed in container by dsub
         # Get input files.  This will run on all files in ./input_data/
-        input_files = self.get_input()
+        #input_files = self.get_input()
 
 
         #input_file = os.path.join("input_data", self.file)
         #input_files = [input_file]
 
-        print("Found %s files to process" % len(input_files))
+        #print("Found %s files to process" % len(input_files))
 
-        if len(input_files) == 0:
-            print("No input files found.  Exiting.")
-            exit()
+        #if len(input_files) == 0:
+        #    print("No input files found.  Exiting.")
+        #    exit()
 
         # This will actually be a single step with a bed file passed to break blocks
         # Output will automaticaly be written to the output directory.  The VCF will be named based on the input VCF.
 
-        for f in input_files:
-            print("Processing %s" % f)
-            break_blocks(f, self.fasta, self.bed, self.debug)
+        #for f in input_files:
+        #    print("Processing %s" % f)
+        break_blocks(
+                     vcf = self.vcf, 
+                     fasta = self.fasta, 
+                     output = self.output,
+                     index = self.index, 
+                     bed = self.bed,
+                     debug = self.debug)
 
     def get_input(self):
         # get all the vcf.gz files in a directory
@@ -72,10 +81,14 @@ Parse the command line
 def parse_command_line():
     parser = argparse.ArgumentParser(
         description = 'This is a script I wrote')
-    parser.add_argument("-f", "--vcf", help="gVCF to process")
+    parser.add_argument("-v", "--vcf", help="gVCF to process")
     parser.add_argument("-b", "--bed", help="Bed file for subsetting genotypes")
     parser.add_argument("--fasta", help="Indexed reference genome fasta file.  Index must be in the same location")
-    parser.add_argument("-o", "--output", help="Output file")
+    parser.add_argument("-o", "--output", help="Output bcf file")
+    # (pbilling) Specifying index name because dsub needs to manage 
+    #   file paths of all inputs/outputs in order to do delocalize
+    #   to Google Cloud Storage
+    parser.add_argument("-i", "--index", help="Output bcf index")
     parser.add_argument("-d", "--debug", action='store_true', default=False,
                                 help="Output debugging messages.  May be very verbose.")
     options = parser.parse_args()
@@ -92,6 +105,7 @@ if __name__ == "__main__":
                      bed=options.bed,
                      fasta=options.fasta,
                      output=options.output,
+                     index=options.index,
                      debug=options.debug)
     ep.run()
 


### PR DESCRIPTION
Hi Greg,

I've made some changes to better support running these jobs via dsub. Namely, all the inputs and outputs that need to be de/localized from GCS are stored as variables. This is because Dsub controls the paths that are used for files on the VM. I also added some print statements & did some minor reformatting. Oh and I scrapped the build packs image because I couldn't get it to work with dsub, but creating an image from your source materials was very simple; I've included a Dockerfile and instructions for creating a docker image and running jobs via Dsub in the README.

There does seem to be an issue with the final output; it looks like the header of the bcf is compressed in a different way than the body, so running gunzip on the output generates a readable header but not body. I'm not sure why this is happening but hoping you can resolve it. Other than that, I think it looks good.

Making each of these steps compatible with Dsub is probably the most important step to getting them to work in a production environment, so if you can do that, it'll make it much quicker for me to integrate them.

Best,
Paul